### PR TITLE
refactor: clean up comments and docs

### DIFF
--- a/Core/Scheduler/scheduler.py
+++ b/Core/Scheduler/scheduler.py
@@ -34,8 +34,12 @@ class BaselineScheduler:
     def _feed(self, now, tasks):
         ids = {t.id for t in self.waiting_tasks}
         for t in tasks:
-            # 아직 시작시각 도달 & 미완료면 큐에 투입
-            if t.start_time <= now and t.id not in ids and any(st is None for st, _ in t.scene_allocation_data):
+            # Add task to queue if its start time has arrived and it still has unassigned scenes
+            if (
+                t.start_time <= now
+                and t.id not in ids
+                and any(st is None for st, _ in t.scene_allocation_data)
+            ):
                 self.waiting_tasks.append(t)
         self.waiting_tasks.sort(key=lambda t: t.start_time)
 
@@ -43,7 +47,7 @@ class BaselineScheduler:
         new: List[Assignment] = []
         remain = []
         for t in self.selector.select(now, self.waiting_tasks):
-            # [CHANGED] 전부 완료면 건너뜀
+            # Skip tasks that are already complete
             if all(st is not None for st, _ in t.scene_allocation_data):
                 continue
 
@@ -58,7 +62,7 @@ class BaselineScheduler:
             new_assgn = self.dispatcher.dispatch(t, cmb, now, ps, self.evaluator, self.verbose)
             new += new_assgn
             after_missing = sum(1 for st, _ in t.scene_allocation_data if st is None)
-            # [CHANGED] 여전히 남은 씬이 있으면 다음 스텝에서도 고려
+            # Keep tasks with remaining scenes for the next iteration
             if after_missing > 0:
                 remain.append(t)
         self.waiting_tasks = remain
@@ -68,7 +72,7 @@ class BaselineScheduler:
             time_start: datetime.datetime | None = None,
             time_end: datetime.datetime | None = None) -> List[Assignment]:
         if time_start is None:
-            # provider available_hours 가 비어있을 수 있음에 주의
+            # Note: provider available_hours may be empty
             starts = []
             for p in ps:
                 if getattr(p, 'available_hours', None):

--- a/Core/scheduler.py
+++ b/Core/scheduler.py
@@ -1,5 +1,5 @@
 # ================================================================
-# scheduler.py  – 공용 인터페이스 래퍼
+# scheduler.py – common interface wrapper
 # ================================================================
 from __future__ import annotations
 import datetime
@@ -9,10 +9,10 @@ from Model.tasks import Tasks
 from Model.providers import Providers
 from Core.Scheduler.scheduler import BaselineScheduler as _BaselineScheduler
 
-# ---------- 공통 Assignment 형식 ----------
+# ---------- Common Assignment type ----------
 Assignment = Tuple[str, int, datetime.datetime, datetime.datetime, int]
 
-# ---------- 스케줄러 최소 프로토콜 ----------
+# ---------- Minimum scheduler protocol ----------
 class Scheduler(Protocol):
     def run(
         self,

--- a/Model/providers.py
+++ b/Model/providers.py
@@ -1,20 +1,23 @@
-#CLEAR
+"""Provider model definitions."""
 
 from __future__ import annotations
 import datetime
 from typing import Dict, Any, List, Tuple, Optional
 from utils.utils import merge_intervals
 
+
 class Provider:
     def __init__(self, d: Dict[str, Any]):
-        self.throughput: float = float(d.get("throughput", 1.0))          # GFLOP/s
-        self.price_per_gpu_hour: float = float(d.get("price", 0.0))       # $
-        self.bandwidth: float = float(d.get("bandwidth", 0.0))            # MB/s
+        self.throughput: float = float(d.get("throughput", 1.0))  # GFLOP/s
+        self.price_per_gpu_hour: float = float(d.get("price", 0.0))  # $
+        self.bandwidth: float = float(d.get("bandwidth", 0.0))  # MB/s
 
         raw = d.get("available_hours", [])
         self.available_hours: List[Tuple[datetime.datetime, datetime.datetime]] = [
-            (datetime.datetime.fromisoformat(s) if isinstance(s, str) else s,
-             datetime.datetime.fromisoformat(e) if isinstance(e, str) else e)
+            (
+                datetime.datetime.fromisoformat(s) if isinstance(s, str) else s,
+                datetime.datetime.fromisoformat(e) if isinstance(e, str) else e,
+            )
             for s, e in raw
         ]
 
@@ -22,53 +25,78 @@ class Provider:
         self.schedule: List[Tuple[str, int, datetime.datetime, datetime.datetime]] = []
 
     # ---------------------------------------------------
-    # 메트릭
+    # Metrics
     # ---------------------------------------------------
-    def idle_ratio(self, start: Optional[datetime.datetime] = None,
-                   end: Optional[datetime.datetime] = None) -> float:
-        if not self.schedule: return 1.0
-        if start is None: start = min(s for *_ ,s,_ in self.schedule)
-        if end   is None: end   = max(f for *_,f in self.schedule)
+    def idle_ratio(
+        self,
+        start: Optional[datetime.datetime] = None,
+        end: Optional[datetime.datetime] = None,
+    ) -> float:
+        if not self.schedule:
+            return 1.0
+        if start is None:
+            start = min(s for *_, s, _ in self.schedule)
+        if end is None:
+            end = max(f for *_, f in self.schedule)
         horizon = (end - start).total_seconds() / 3600.0
-        if horizon <= 0: return 1.0
-        busy = merge_intervals([(s,f) for *_ ,s,f in self.schedule])
-        busy_h = sum((f-s).total_seconds()/3600.0 for s,f in busy)
-        return max(0.0, 1.0 - busy_h/horizon)
+        if horizon <= 0:
+            return 1.0
+        busy = merge_intervals([(s, f) for *_, s, f in self.schedule])
+        busy_h = sum((f - s).total_seconds() / 3600.0 for s, f in busy)
+        return max(0.0, 1.0 - busy_h / horizon)
 
     # ---------------------------------------------------
-    # 스케줄링 헬퍼
+    # Scheduling helpers
     # ---------------------------------------------------
     def earliest_available(self, dur_h: float, after: datetime.datetime) -> Optional[datetime.datetime]:
-        """지정 길이(dur_h)를 연속으로 배정할 수 있는 가장 이른 시각(>=after)"""
+        """Earliest time (>= after) to allocate a contiguous block of length dur_h."""
         for a_s, a_e in sorted(self.available_hours, key=lambda t: t[0]):
-            if a_e <= after: continue
+            if a_e <= after:
+                continue
             cur = max(a_s, after)
 
-            # 해당 윈도우 내 기존 schedule 과 겹치지 않는 구간 찾기
-            clashes = sorted([(s,f) for *_,s,f in self.schedule if s < a_e and f > cur], key=lambda iv: iv[0])
-            for s,f in clashes:
-                if (s - cur).total_seconds()/3600.0 >= dur_h: return cur
+            # Find a gap within the window that does not clash with existing schedule
+            clashes = sorted(
+                [(s, f) for *_, s, f in self.schedule if s < a_e and f > cur],
+                key=lambda iv: iv[0],
+            )
+            for s, f in clashes:
+                if (s - cur).total_seconds() / 3600.0 >= dur_h:
+                    return cur
                 cur = max(cur, f)
-            if (a_e - cur).total_seconds()/3600.0 >= dur_h: return cur
+            if (a_e - cur).total_seconds() / 3600.0 >= dur_h:
+                return cur
         return None
 
-    def assign(self, task_id: str, scene_id: int,
-               start: datetime.datetime, dur_h: float):
+    def assign(self, task_id: str, scene_id: int, start: datetime.datetime, dur_h: float):
         finish = start + datetime.timedelta(hours=dur_h)
         self.schedule.append((task_id, scene_id, start, finish))
 
-        # available_hours 업데이트(틈새 제거)
-        new=[]
-        for s,e in self.available_hours:
-            if finish <= s or start >= e: new.append((s,e)); continue
-            if s < start: new.append((s,start))
-            if finish < e: new.append((finish,e))
-        self.available_hours=new
+        # Update available_hours by removing the allocated interval
+        new: List[Tuple[datetime.datetime, datetime.datetime]] = []
+        for s, e in self.available_hours:
+            if finish <= s or start >= e:
+                new.append((s, e))
+                continue
+            if s < start:
+                new.append((s, start))
+            if finish < e:
+                new.append((finish, e))
+        self.available_hours = new
+
 
 class Providers:
-    def __init__(self): self._list: List[Provider]=[]
+    def __init__(self):
+        self._list: List[Provider] = []
+
     def initialize_from_data(self, data):
-        self._list=[Provider(d) for d in data]
-    def __iter__(self): return iter(self._list)
-    def __getitem__(self,i): return self._list[i]
-    def __len__(self): return len(self._list)
+        self._list = [Provider(d) for d in data]
+
+    def __iter__(self):
+        return iter(self._list)
+
+    def __getitem__(self, i):
+        return self._list[i]
+
+    def __len__(self):
+        return len(self._list)

--- a/Model/tasks.py
+++ b/Model/tasks.py
@@ -1,49 +1,55 @@
-# CLEAR
+"""Task data models used by the simulator."""
 
 from __future__ import annotations
 import datetime
 from typing import Dict, List, Tuple, Optional, Any
 
+
 class Task:
     def __init__(self, d: Dict[str, Any]):
         self.id: str = d["id"]
         self.global_file_size: float = float(d.get("global_file_size", 0.0))  # MB
-        self.scene_number: int = int(d.get("scene_number", 1))
+        self.scene_number: int = int(d.get("scene_number", 1))  # number of scenes
 
-        # scene_file_size: 스칼라(모든 씬 동일) 또는 리스트
+        # scene_file_size may be a scalar (same for all scenes) or a list
         sf = d.get("scene_file_size", 0.0)
         self.scene_file_sizes: List[float] = (
-            list(map(float, sf)) if isinstance(sf, list)
-            else [float(sf)] * self.scene_number
+            list(map(float, sf)) if isinstance(sf, list) else [float(sf)] * self.scene_number
         )
         if len(self.scene_file_sizes) != self.scene_number:
-            raise ValueError("scene_file_size 길이와 scene_number 불일치")
+            raise ValueError("scene_file_size length mismatch with scene_number")
 
-        self.scene_workload: float = float(d.get("scene_workload", 0.0))  # GFLOPs 등
-        self.bandwidth: float = float(d.get("bandwidth", 0.0))            # MB/s
+        self.scene_workload: float = float(d.get("scene_workload", 0.0))  # GFLOPs or similar
+        self.bandwidth: float = float(d.get("bandwidth", 0.0))  # MB/s
         self.budget: float = float(d.get("budget", float("inf")))
 
         self.deadline: datetime.datetime = (
-            datetime.datetime.fromisoformat(d["deadline"]) if isinstance(d["deadline"], str)
-            else d["deadline"]
+            datetime.datetime.fromisoformat(d["deadline"]) if isinstance(d["deadline"], str) else d["deadline"]
         )
         self.start_time: datetime.datetime = (
-            datetime.datetime.fromisoformat(d["start_time"]) if isinstance(d["start_time"], str)
-            else d["start_time"]
+            datetime.datetime.fromisoformat(d["start_time"]) if isinstance(d["start_time"], str) else d["start_time"]
         )
 
-        # (start_time, provider_idx) per scene
+        # (start_time, provider_idx) for each scene
         self.scene_allocation_data: List[Tuple[Optional[datetime.datetime], Optional[int]]] = [
             (None, None) for _ in range(self.scene_number)
         ]
 
-    # 헬퍼
+    # Helpers
     def scene_size(self, idx: int) -> float:
         return self.scene_file_sizes[idx]
 
+
 class Tasks:
-    def __init__(self): self._dict: Dict[str, Task] = {}
+    def __init__(self):
+        self._dict: Dict[str, Task] = {}
+
     def initialize_from_data(self, data):
-        for d in data: self._dict[d["id"]] = Task(d)
-    def __iter__(self): return iter(self._dict.values())
-    def __getitem__(self, k): return self._dict[k]
+        for d in data:
+            self._dict[d["id"]] = Task(d)
+
+    def __iter__(self):
+        return iter(self._dict.values())
+
+    def __getitem__(self, k):
+        return self._dict[k]

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -1,16 +1,22 @@
-# CLEAR
+"""Utility helpers used across the project."""
 
 from __future__ import annotations
 import datetime
 from typing import List, Tuple
 
-def merge_intervals(iv: List[Tuple[datetime.datetime, datetime.datetime]]):
-    """겹치거나 맞닿은 구간을 병합"""
-    if not iv: return []
-    iv.sort(key=lambda t:t[0])
-    merged=[list(iv[0])]
-    for s,e in iv[1:]:
-        m_s,m_e=merged[-1]
-        if s <= m_e: merged[-1][1]=max(m_e,e)
-        else: merged.append([s,e])
-    return [(s,e) for s,e in merged]
+
+def merge_intervals(
+    iv: List[Tuple[datetime.datetime, datetime.datetime]]
+) -> List[Tuple[datetime.datetime, datetime.datetime]]:
+    """Merge overlapping or adjacent intervals."""
+    if not iv:
+        return []
+    iv.sort(key=lambda t: t[0])
+    merged = [list(iv[0])]
+    for s, e in iv[1:]:
+        m_s, m_e = merged[-1]
+        if s <= m_e:
+            merged[-1][1] = max(m_e, e)
+        else:
+            merged.append([s, e])
+    return [(s, e) for s, e in merged]


### PR DESCRIPTION
## Summary
- translate and tidy comments across scheduler and model modules
- add module docstrings and utility descriptions
- improve simulator documentation and readability

## Testing
- `python -m py_compile simulator.py Model/tasks.py Model/providers.py utils/utils.py Core/scheduler.py Core/Scheduler/scheduler.py`
- `MPLBACKEND=Agg python simulator.py --config config.json --algo bf --out-img schedule.png -v` *(fails: No module named 'matplotlib')*
- `pip install matplotlib` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689d77a03db883238f337e78cdde35bd