### PR TITLE
Add Hungarian combo generator

### DIFF
--- a/Core/Scheduler/combo_generator/hungarian.py
+++ b/Core/Scheduler/combo_generator/hungarian.py
@@ -1,0 +1,132 @@
+# Core/Scheduler/combo_generator/hungarian.py
+"""Hungarian algorithm based combo generator.
+
+Constructs a cost matrix between scenes and providers and solves
+assignment with the Hungarian algorithm. Impossible matches get a
+very large cost so they are avoided. Time complexity of the solver is
+O(n^3) where n = max(number of scenes, providers).
+
+Compared to brute-force search which explores exponential number of
+combinations, this method yields the optimal assignment for the given
+pairwise costs while remaining polynomial time. Quality is identical
+whenever the overall objective is the sum of individual costs.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import List, Optional, Tuple
+
+from Core.Scheduler.interface import ComboGenerator
+
+_BIG = 10 ** 9
+_SKIP_COST = 10 ** 6
+
+
+def _hungarian(cost: List[List[float]]) -> List[int]:
+    """Return optimal column index for each row using Hungarian algorithm."""
+    if not cost:
+        return []
+    n, m = len(cost), len(cost[0])
+    transpose = False
+    if n > m:
+        cost = [list(row) for row in zip(*cost)]
+        n, m = m, n
+        transpose = True
+    u = [0.0] * (n + 1)
+    v = [0.0] * (m + 1)
+    p = [0] * (m + 1)
+    way = [0] * (m + 1)
+    for i in range(1, n + 1):
+        p[0] = i
+        j0 = 0
+        minv = [float("inf")] * (m + 1)
+        used = [False] * (m + 1)
+        while True:
+            used[j0] = True
+            i0 = p[j0]
+            delta = float("inf")
+            j1 = 0
+            for j in range(1, m + 1):
+                if not used[j]:
+                    cur = cost[i0 - 1][j - 1] - u[i0] - v[j]
+                    if cur < minv[j]:
+                        minv[j] = cur
+                        way[j] = j0
+                    if minv[j] < delta:
+                        delta = minv[j]
+                        j1 = j
+            for j in range(m + 1):
+                if used[j]:
+                    u[p[j]] += delta
+                    v[j] -= delta
+                else:
+                    minv[j] -= delta
+            j0 = j1
+            if p[j0] == 0:
+                break
+        while True:
+            j1 = way[j0]
+            p[j0] = p[j1]
+            j0 = j1
+            if j0 == 0:
+                break
+    ans = [-1] * n
+    for j in range(1, m + 1):
+        if p[j] != 0:
+            ans[p[j] - 1] = j - 1
+    if transpose:
+        return ans
+    return ans
+
+
+class HungarianComboGenerator(ComboGenerator):
+    def best_combo(
+        self,
+        task,
+        providers,
+        sim_time,
+        evaluator,
+        verbose: bool = False,
+    ) -> Optional[Tuple[List[int], float, float]]:
+        # gather unassigned scenes
+        scene_ids = [
+            i for i, (st, _) in enumerate(task.scene_allocation_data) if st is None
+        ]
+        if not scene_ids:
+            return None
+        S = len(scene_ids)
+        P = len(providers)
+
+        cost_mat: List[List[float]] = []
+        for idx, sid in enumerate(scene_ids):
+            row: List[float] = []
+            for prov in providers:
+                d, _ = evaluator.time_cost(task, sid, prov)
+                if not math.isfinite(d) or d <= 0:
+                    row.append(_BIG)
+                else:
+                    row.append(d)
+            # skip columns so that each scene may remain unassigned
+            skip_cols = [_BIG] * S
+            skip_cols[idx] = _SKIP_COST
+            row.extend(skip_cols)
+            cost_mat.append(row)
+
+        assign = _hungarian(cost_mat)
+
+        combo = [-1] * task.scene_number
+        for sid, col in zip(scene_ids, assign[:S]):
+            if col < P:
+                combo[sid] = col
+            else:
+                combo[sid] = -1
+
+        ok, t_tot, cost, deferred, overB, overDL = evaluator.feasible(
+            task, combo, sim_time, providers
+        )
+        if not ok:
+            return None
+        # efficiency not needed for single assignment; still compute to mimic BF
+        evaluator.efficiency(task, combo, providers, sim_time, t_tot, cost, deferred, overB, overDL)
+        return combo, t_tot, cost

--- a/Core/Scheduler/registry.py
+++ b/Core/Scheduler/registry.py
@@ -1,9 +1,10 @@
 from Core.Scheduler.task_selector.fifo import FIFOTaskSelector
 from Core.Scheduler.metric_evaluator.baseline import BaselineEvaluator
 from Core.Scheduler.combo_generator.brute_force import BruteForceGenerator
+from Core.Scheduler.combo_generator.hungarian import HungarianComboGenerator
 from Core.Scheduler.dispatcher.sequential import SequentialDispatcher
 
-COMBO_REG = {"bf": BruteForceGenerator}
+COMBO_REG = {"bf": BruteForceGenerator, "hungarian": HungarianComboGenerator}
 
 DISP_REG = {"bf": SequentialDispatcher}
 

--- a/tests/test_hungarian.py
+++ b/tests/test_hungarian.py
@@ -1,0 +1,55 @@
+import os
+import sys
+import datetime as dt
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from Core.Scheduler.combo_generator.brute_force import BruteForceGenerator
+from Core.Scheduler.combo_generator.hungarian import HungarianComboGenerator
+from Core.Scheduler.metric_evaluator.baseline import BaselineEvaluator
+from Model.tasks import Task
+from Model.providers import Providers
+
+
+def _sample_case():
+    now = dt.datetime(2024, 1, 1, 0, 0, 0)
+    task_data = {
+        "id": "T1",
+        "global_file_size": 0.0,
+        "scene_number": 2,
+        "scene_file_size": [0.0, 0.0],
+        "scene_workload": 10.0,
+        "bandwidth": 10.0,
+        "budget": 1000.0,
+        "deadline": now + dt.timedelta(hours=10),
+        "start_time": now,
+    }
+    task = Task(task_data)
+    prov_data = [
+        {
+            "throughput": 10.0,
+            "price": 1.0,
+            "bandwidth": 10.0,
+            "available_hours": [(now, now + dt.timedelta(hours=5))],
+        },
+        {
+            "throughput": 5.0,
+            "price": 1.0,
+            "bandwidth": 10.0,
+            "available_hours": [(now, now + dt.timedelta(hours=5))],
+        },
+    ]
+    providers = Providers()
+    providers.initialize_from_data(prov_data)
+    return task, providers, now
+
+
+def test_hungarian_matches_bruteforce():
+    task, providers, now = _sample_case()
+    evaluator = BaselineEvaluator()
+    bf = BruteForceGenerator()
+    hg = HungarianComboGenerator()
+
+    res_bf = bf.best_combo(task, providers, now, evaluator)
+    res_hg = hg.best_combo(task, providers, now, evaluator)
+    assert res_hg == res_bf


### PR DESCRIPTION
## Summary
- Implement a Hungarian algorithm-based combo generator with O(n^3) complexity and skip penalties
- Register Hungarian combo generator in scheduler registry
- Add tests ensuring Hungarian output matches brute force

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689d7cf451708323851cdcc28385e82f