### PR TITLE
Add EDF task selector and hybrid CP combo generator

### DIFF
--- a/Core/Scheduler/combo_generator/hybrid_cp.py
+++ b/Core/Scheduler/combo_generator/hybrid_cp.py
@@ -1,0 +1,67 @@
+"""Hybrid combo generator combining greedy pruning with CP-SAT optimisation."""
+
+from __future__ import annotations
+
+import math
+from typing import List
+
+from Core.Scheduler.interface import ComboGenerator
+from Core.Scheduler.combo_generator.cpsat import CPSatComboGenerator
+from Core.Scheduler.combo_generator.greedy import GreedyComboGenerator
+
+
+class HybridCPComboGenerator(ComboGenerator):
+    """CP-SAT with provider pruning and greedy fallback.
+
+    For each unassigned scene only the top ``k`` providers (shortest estimated
+    duration) are considered. The reduced provider set is optimised via the
+    existing :class:`CPSatComboGenerator`. If CP-SAT fails to find a feasible
+    solution, the algorithm falls back to the greedy heuristic.
+    """
+
+    def __init__(self, k: int = 3):
+        self.k = k
+        self._cp = CPSatComboGenerator()
+        self._greedy = GreedyComboGenerator()
+
+    # --- helpers ---------------------------------------------------------
+    def _select_providers(self, t, ps, ev):
+        """Return subset of providers and mapping to original indices."""
+        # Always keep providers that already host some scenes
+        chosen = {p for _, p in t.scene_allocation_data if p is not None}
+        unassigned = [i for i, (st, _) in enumerate(t.scene_allocation_data) if st is None]
+        for sid in unassigned:
+            candidates = []
+            for pid, prov in enumerate(ps):
+                d, _ = ev.time_cost(t, sid, prov)
+                if math.isfinite(d):
+                    candidates.append((d, pid))
+            candidates.sort(key=lambda x: x[0])
+            for _, pid in candidates[: self.k]:
+                chosen.add(pid)
+        idx = sorted(chosen)
+        subset_ps = [ps[i] for i in idx]
+        mapping = {new: old for new, old in enumerate(idx)}
+        return subset_ps, mapping
+
+    # --- interface -------------------------------------------------------
+    def time_complexity(self, t, ps, now, ev):
+        subset, _ = self._select_providers(t, ps, ev)
+        return self._cp.time_complexity(t, subset, now, ev)
+
+    def best_combo(self, t, ps, now, ev, verbose=False):
+        subset_ps, mapping = self._select_providers(t, ps, ev)
+        if not subset_ps:
+            return None
+        res = self._cp.best_combo(t, subset_ps, now, ev, verbose)
+        if res is None:
+            return self._greedy.best_combo(t, ps, now, ev, verbose)
+        cmb_subset, t_tot, cost = res
+        # Map indices back to original provider list
+        cmb_full: List[int] = []
+        for p in cmb_subset:
+            if p == -1:
+                cmb_full.append(-1)
+            else:
+                cmb_full.append(mapping[p])
+        return cmb_full, t_tot, cost

--- a/Core/Scheduler/registry.py
+++ b/Core/Scheduler/registry.py
@@ -10,10 +10,13 @@ DISP_REG = {"bf": SequentialDispatcher, "greedy": SequentialDispatcher}
 
 try:
     from Core.Scheduler.combo_generator.cpsat import CPSatComboGenerator
+    from Core.Scheduler.combo_generator.hybrid_cp import HybridCPComboGenerator
     from Core.Scheduler.dispatcher.sequential import CPSatDispatcher
     if CPSatComboGenerator:
         COMBO_REG["cp"] = CPSatComboGenerator
         DISP_REG["cp"] = CPSatDispatcher
+        COMBO_REG["hybrid_cp"] = HybridCPComboGenerator
+        DISP_REG["hybrid_cp"] = CPSatDispatcher
 except ImportError:
     print("ERROR")
     pass

--- a/Core/Scheduler/task_selector/edf_priority.py
+++ b/Core/Scheduler/task_selector/edf_priority.py
@@ -1,0 +1,28 @@
+"""Earliest-Deadline-First task selector with budget-aware tie-break."""
+
+from __future__ import annotations
+
+import datetime
+from typing import List, Sequence
+
+from Core.Scheduler.interface import TaskSelector
+from Model.tasks import Task
+
+
+class EDFPriorityTaskSelector(TaskSelector):
+    """Order tasks by slack and budget efficiency.
+
+    Tasks with the smallest time *slack* (deadline minus current time) are
+    prioritized. When two tasks have similar slack, the one with higher budget
+    per remaining scene is selected first.
+    """
+
+    def select(self, now: datetime.datetime, waiting: Sequence[Task]) -> List[Task]:
+        def score(t: Task) -> tuple[float, float]:
+            remaining = sum(st is None for st, _ in t.scene_allocation_data)
+            if remaining <= 0:
+                remaining = 1  # avoid division by zero; complete tasks are filtered elsewhere
+            slack_hours = (t.deadline - now).total_seconds() / 3600.0
+            return (slack_hours, -t.budget / remaining)
+
+        return sorted(waiting, key=score)


### PR DESCRIPTION
## Summary
- implement budget-aware EDFPriorityTaskSelector for ordering waiting tasks
- add HybridCPComboGenerator that prunes providers and falls back to greedy
- expose new hybrid_cp algorithm via scheduler registry

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d967ab4fc8323a649b4cfd40b3414