### PR TITLE
Expose heuristic combo generators in CLI and tests

### DIFF
--- a/Core/Scheduler/combo_generator/genetic.py
+++ b/Core/Scheduler/combo_generator/genetic.py
@@ -1,0 +1,104 @@
+# Core/Scheduler/combo_generator/genetic.py
+from __future__ import annotations
+
+import random
+from typing import List, Tuple
+
+from Core.Scheduler.interface import ComboGenerator
+
+
+class GeneticComboGenerator(ComboGenerator):
+    """Genetic algorithm for combo generation.
+
+    A small population of candidate combinations is evolved through
+    crossover and mutation. The population size and number of generations
+    are chosen so that the total number of evaluated combinations does not
+    exceed ``(scene_cnt * provider_cnt) ** 1.5``.
+    """
+
+    def __init__(self, pop_size: int = 20, factor: float = 1.0, mutation: float = 0.1):
+        self.pop_size = pop_size
+        self.factor = factor
+        self.mutation = mutation
+
+    def time_complexity(self, t, ps, now, ev):
+        scene_ids = [i for i, (st, _) in enumerate(t.scene_allocation_data) if st is None]
+        n = len(scene_ids) * len(ps)
+        return int(self.factor * (n ** 1.5))
+
+    def _random_combo(self, t, ps, scene_ids: List[int]) -> List[int]:
+        cmb = [-1] * t.scene_number
+        used = set()
+        for sid in scene_ids:
+            choices = [-1] + [pid for pid in range(len(ps)) if pid not in used]
+            pid = random.choice(choices)
+            if pid != -1:
+                used.add(pid)
+            cmb[sid] = pid
+        return cmb
+
+    def _evaluate(self, t, ps, now, ev, cmb: List[int]) -> Tuple[float, Tuple[List[int], float, float]]:
+        ok, t_tot, cost, deferred, overB, overDL = ev.feasible(t, cmb, now, ps)
+        if not ok:
+            return float("-inf"), (cmb, 0.0, 0.0)
+        score = ev.efficiency(t, cmb, ps, now, t_tot, cost, deferred, overB, overDL)
+        return score, (cmb, t_tot, cost)
+
+    def _crossover(self, a: List[int], b: List[int], ps_len: int) -> List[int]:
+        child = [-1] * len(a)
+        used = set()
+        for i in range(len(a)):
+            pid = random.choice([a[i], b[i]])
+            if pid != -1 and pid in used:
+                pid = -1
+            if pid != -1:
+                used.add(pid)
+            child[i] = pid
+        return child
+
+    def _mutate(self, cmb: List[int], ps_len: int):
+        used = {pid for pid in cmb if pid != -1}
+        for i in range(len(cmb)):
+            if random.random() < self.mutation:
+                choices = [-1] + [pid for pid in range(ps_len) if pid not in used or pid == cmb[i]]
+                new_pid = random.choice(choices)
+                if cmb[i] != -1:
+                    used.discard(cmb[i])
+                if new_pid != -1:
+                    used.add(new_pid)
+                cmb[i] = new_pid
+
+    def best_combo(self, t, ps, now, ev, verbose=False):
+        scene_ids = [i for i, (st, _) in enumerate(t.scene_allocation_data) if st is None]
+        if not scene_ids:
+            return None
+
+        eval_budget = self.time_complexity(t, ps, now, ev)
+        pop_size = min(self.pop_size, max(1, eval_budget))
+        generations = max(1, eval_budget // pop_size)
+
+        population: List[Tuple[float, Tuple[List[int], float, float]]] = []
+        while len(population) < pop_size:
+            cmb = self._random_combo(t, ps, scene_ids)
+            score, res = self._evaluate(t, ps, now, ev, cmb)
+            if score > float("-inf"):
+                population.append((score, res))
+        best_score, best_res = max(population, key=lambda x: x[0])
+
+        for _ in range(generations):
+            population.sort(key=lambda x: x[0], reverse=True)
+            elites = population[: max(1, pop_size // 2)]
+            new_pop = elites.copy()
+            while len(new_pop) < pop_size:
+                p1, p2 = random.sample(elites, k=2)
+                child = self._crossover(p1[1][0], p2[1][0], len(ps))
+                self._mutate(child, len(ps))
+                score, res = self._evaluate(t, ps, now, ev, child)
+                if score > float("-inf"):
+                    new_pop.append((score, res))
+                    if score > best_score:
+                        best_score, best_res = score, res
+            population = new_pop
+
+        return best_res if best_score > float("-inf") else None
+

--- a/Core/Scheduler/combo_generator/monte_carlo.py
+++ b/Core/Scheduler/combo_generator/monte_carlo.py
@@ -1,0 +1,62 @@
+# Core/Scheduler/combo_generator/monte_carlo.py
+from __future__ import annotations
+
+import random
+from typing import List
+
+from Core.Scheduler.interface import ComboGenerator
+
+
+class MonteCarloComboGenerator(ComboGenerator):
+    """Randomised search for scene-provider assignments.
+
+    The algorithm samples random combinations while respecting the
+    "one scene per provider" constraint. Among all sampled combinations
+    the one with the highest efficiency score is returned. The number of
+    samples is bounded by ``(scene_cnt * provider_cnt) ** 1.5`` to keep
+    the time complexity below the required ``timestep * (scene *
+    provider) ** 1.5`` limit.
+    """
+
+    def __init__(self, factor: float = 1.0):
+        self.factor = factor
+
+    def time_complexity(self, t, ps, now, ev):
+        scene_ids = [i for i, (st, _) in enumerate(t.scene_allocation_data) if st is None]
+        n = len(scene_ids) * len(ps)
+        return int(self.factor * (n ** 1.5))
+
+    def _random_combo(self, t, ps, scene_ids: List[int]) -> List[int]:
+        cmb = [-1] * t.scene_number
+        used = set()
+        for sid in scene_ids:
+            choices = [-1] + [pid for pid in range(len(ps)) if pid not in used]
+            pid = random.choice(choices)
+            if pid != -1:
+                used.add(pid)
+            cmb[sid] = pid
+        return cmb
+
+    def best_combo(self, t, ps, now, ev, verbose=False):
+        scene_ids = [i for i, (st, _) in enumerate(t.scene_allocation_data) if st is None]
+        if not scene_ids:
+            return None
+
+        samples = self.time_complexity(t, ps, now, ev)
+        best_score = float("-inf")
+        best_res = None
+
+        for _ in range(samples):
+            cmb = self._random_combo(t, ps, scene_ids)
+            if all(pid == -1 for pid in cmb):
+                continue
+            ok, t_tot, cost, deferred, overB, overDL = ev.feasible(t, cmb, now, ps)
+            if not ok:
+                continue
+            score = ev.efficiency(t, cmb, ps, now, t_tot, cost, deferred, overB, overDL)
+            if score > best_score:
+                best_score = score
+                best_res = (cmb.copy(), t_tot, cost)
+
+        return best_res
+

--- a/Core/Scheduler/combo_generator/simulated_annealing.py
+++ b/Core/Scheduler/combo_generator/simulated_annealing.py
@@ -1,0 +1,81 @@
+# Core/Scheduler/combo_generator/simulated_annealing.py
+from __future__ import annotations
+
+import math
+import random
+from typing import List
+
+from Core.Scheduler.interface import ComboGenerator
+from Core.Scheduler.combo_generator.greedy import GreedyComboGenerator
+
+
+class SimulatedAnnealingComboGenerator(ComboGenerator):
+    """Simulated annealing based combo generator.
+
+    Starting from a greedy solution, the algorithm performs random local
+    modifications and accepts them based on the Metropolis criterion. The
+    temperature is decreased multiplicatively each iteration. The number of
+    iterations is capped at ``(scene_cnt * provider_cnt) ** 1.5``.
+    """
+
+    def __init__(self, factor: float = 1.0, start_temp: float = 1.0, cooling: float = 0.99):
+        self.factor = factor
+        self.start_temp = start_temp
+        self.cooling = cooling
+
+    def time_complexity(self, t, ps, now, ev):
+        scene_ids = [i for i, (st, _) in enumerate(t.scene_allocation_data) if st is None]
+        n = len(scene_ids) * len(ps)
+        return int(self.factor * (n ** 1.5))
+
+    def _initial_solution(self, t, ps, now, ev):
+        greedy = GreedyComboGenerator().best_combo(t, ps, now, ev)
+        if greedy is None:
+            return None
+        cmb, t_tot, cost = greedy
+        ok, t_tot, cost, deferred, overB, overDL = ev.feasible(t, cmb, now, ps)
+        if not ok:
+            return None
+        score = ev.efficiency(t, cmb, ps, now, t_tot, cost, deferred, overB, overDL)
+        return cmb, t_tot, cost, score
+
+    def _random_neighbor(self, t, ps, scene_ids: List[int], cmb: List[int]) -> List[int]:
+        new_cmb = cmb.copy()
+        sid = random.choice(scene_ids)
+        used = {pid for pid in new_cmb if pid != -1 and pid != new_cmb[sid]}
+        choices = [-1] + [pid for pid in range(len(ps)) if pid not in used]
+        new_cmb[sid] = random.choice(choices)
+        return new_cmb
+
+    def best_combo(self, t, ps, now, ev, verbose=False):
+        scene_ids = [i for i, (st, _) in enumerate(t.scene_allocation_data) if st is None]
+        if not scene_ids:
+            return None
+
+        start = self._initial_solution(t, ps, now, ev)
+        if start is None:
+            return None
+        current_cmb, current_t, current_cost, current_score = start
+        best_cmb, best_t, best_cost, best_score = start
+
+        max_iter = self.time_complexity(t, ps, now, ev)
+        temp = self.start_temp
+        for _ in range(max_iter):
+            cand = self._random_neighbor(t, ps, scene_ids, current_cmb)
+            if all(pid == -1 for pid in cand):
+                temp *= self.cooling
+                continue
+            ok, t_tot, cost, deferred, overB, overDL = ev.feasible(t, cand, now, ps)
+            if not ok:
+                temp *= self.cooling
+                continue
+            score = ev.efficiency(t, cand, ps, now, t_tot, cost, deferred, overB, overDL)
+            delta = score - current_score
+            if delta > 0 or math.exp(delta / max(temp, 1e-6)) > random.random():
+                current_cmb, current_t, current_cost, current_score = cand, t_tot, cost, score
+                if score > best_score:
+                    best_cmb, best_t, best_cost, best_score = cand.copy(), t_tot, cost, score
+            temp *= self.cooling
+
+        return best_cmb, best_t, best_cost
+

--- a/Core/Scheduler/registry.py
+++ b/Core/Scheduler/registry.py
@@ -2,11 +2,28 @@ from Core.Scheduler.task_selector.fifo import FIFOTaskSelector
 from Core.Scheduler.metric_evaluator.baseline import BaselineEvaluator
 from Core.Scheduler.combo_generator.brute_force import BruteForceGenerator
 from Core.Scheduler.combo_generator.greedy import GreedyComboGenerator
+from Core.Scheduler.combo_generator.monte_carlo import MonteCarloComboGenerator
+from Core.Scheduler.combo_generator.simulated_annealing import (
+    SimulatedAnnealingComboGenerator,
+)
+from Core.Scheduler.combo_generator.genetic import GeneticComboGenerator
 from Core.Scheduler.dispatcher.sequential import SequentialDispatcher
 
-COMBO_REG = {"bf": BruteForceGenerator, "greedy": GreedyComboGenerator}
+COMBO_REG = {
+    "bf": BruteForceGenerator,
+    "greedy": GreedyComboGenerator,
+    "monte_carlo": MonteCarloComboGenerator,
+    "anneal": SimulatedAnnealingComboGenerator,
+    "genetic": GeneticComboGenerator,
+}
 
-DISP_REG = {"bf": SequentialDispatcher, "greedy": SequentialDispatcher}
+DISP_REG = {
+    "bf": SequentialDispatcher,
+    "greedy": SequentialDispatcher,
+    "monte_carlo": SequentialDispatcher,
+    "anneal": SequentialDispatcher,
+    "genetic": SequentialDispatcher,
+}
 
 try:
     from Core.Scheduler.combo_generator.cpsat import CPSatComboGenerator

--- a/simulator.py
+++ b/simulator.py
@@ -160,15 +160,22 @@ class Simulator:
 if __name__ == "__main__":
     pa = argparse.ArgumentParser()
     pa.add_argument("--config", default="config.json")
-    pa.add_argument("--algo",   default="bf", help="bf | cp")
+    pa.add_argument(
+        "--algo",
+        default="bf",
+        help=(
+            "bf | greedy | monte_carlo | anneal | genetic | "
+            "cp | hybrid_cp"
+        ),
+    )
     pa.add_argument("--out-img", default="schedule.png", help="Output image path")
     pa.add_argument("-v", action="count", default=0, help="-v: step logs, -vv: detailed logs")
     args = pa.parse_args()
 
     sim = Simulator(args.config)
-    sch = BaselineScheduler(algo=args.algo,
-                            verbose=args.v,
-                            time_gap=datetime.timedelta(minutes=5))
+    sch = BaselineScheduler(
+        algo=args.algo, verbose=args.v, time_gap=datetime.timedelta(minutes=5)
+    )
     sim.schedule(sch)
     pprint.pprint(sim.evaluate(), sort_dicts=False)
     sim.visualize(save_path=args.out_img, show=True)

--- a/tests/test_new_generators.py
+++ b/tests/test_new_generators.py
@@ -1,0 +1,55 @@
+import datetime as dt
+import random
+
+from Model.tasks import Tasks
+from Model.providers import Providers
+from Core.scheduler import BaselineScheduler
+
+
+def make_simple():
+    task_data = [{
+        "id": "T1",
+        "scene_number": 2,
+        "scene_file_size": [10.0, 5.0],
+        "global_file_size": 0.0,
+        "scene_workload": 3600.0,
+        "bandwidth": 10.0,
+        "budget": 100.0,
+        "start_time": dt.datetime(2024, 1, 1, 8, 0),
+        "deadline": dt.datetime(2024, 1, 1, 20, 0),
+    }]
+    tasks = Tasks(); tasks.initialize_from_data(task_data)
+    prov_data = [
+        {
+            "throughput": 3600.0,
+            "price": 2.0,
+            "bandwidth": 20.0,
+            "available_hours": [
+                (dt.datetime(2024, 1, 1, 8, 0), dt.datetime(2024, 1, 1, 12, 0))
+            ],
+        },
+        {
+            "throughput": 3600.0,
+            "price": 3.0,
+            "bandwidth": 20.0,
+            "available_hours": [
+                (dt.datetime(2024, 1, 1, 8, 0), dt.datetime(2024, 1, 1, 12, 0))
+            ],
+        },
+    ]
+    providers = Providers(); providers.initialize_from_data(prov_data)
+    return tasks, providers
+
+
+@__import__('pytest').mark.parametrize(
+    "algo",
+    ["greedy", "monte_carlo", "anneal", "genetic"],
+)
+def test_scheduler_runs_with_registry_algorithms(algo):
+    random.seed(0)
+    tasks, providers = make_simple()
+    sch = BaselineScheduler(algo=algo, time_gap=dt.timedelta(hours=1))
+    assignments = sch.run(tasks, providers)
+    assert assignments, f"{algo} produced no assignments"
+    t = tasks["T1"]
+    assert all(st is not None for st, _ in t.scene_allocation_data)


### PR DESCRIPTION
## Summary
- Document Monte Carlo, simulated annealing, and genetic combo generators in simulator CLI
- Add regression tests exercising scheduler with new combo generators to ensure registry integration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae95e0247c8323bdab3a417a3195c8